### PR TITLE
[Feat] 매칭 시 notiBar 및 currentMatch 상대방 표기 및 취소 버튼 활성화 #9

### DIFF
--- a/components/Layout/CurrentMatch.tsx
+++ b/components/Layout/CurrentMatch.tsx
@@ -6,17 +6,15 @@ import instance from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
 import { reloadMatchState, currentMatchState } from 'utils/recoil/match';
-import { gameTimeToString, isBeforeMin } from 'utils/handleTime';
 import styles from 'styles/Layout/CurrentMatchInfo.module.scss';
 
 export default function CurrentMatch() {
-  const [{ isMatched, enemyTeam, time, slotId }, setCurrentMatch] =
+  const [{ isMatched, enemyTeam, slotId }, setCurrentMatch] =
     useRecoilState(currentMatchState);
   const [reloadMatch, setReloadMatch] = useRecoilState(reloadMatchState);
   const setModal = useSetRecoilState(modalState);
   const setError = useSetRecoilState(errorState);
-  const matchingMessage = time && makeMessage(slotId, isMatched);
-  const blockCancelButton = isBeforeMin(time, 5) && enemyTeam.length;
+  const matchingMessage = slotId && makeMessage(slotId, isMatched);
   const presentPath = useRouter().asPath;
 
   useEffect(() => {
@@ -47,19 +45,11 @@ export default function CurrentMatch() {
           <div className={styles.icon}> ⏰ </div>
           <div className={styles.messageWrapper}>
             {matchingMessage}
-            <EnemyTeam enemyTeam={enemyTeam} time={time} />
+            <EnemyTeam enemyTeam={enemyTeam} slotId={slotId} />
           </div>
         </div>
-        <div
-          className={
-            blockCancelButton ? styles.blockCancelButton : styles.cancelButton
-          }
-        >
-          <input
-            type='button'
-            onClick={onCancel}
-            value={blockCancelButton ? '취소불가' : '취소하기'}
-          />
+        <div className={styles.cancelButton}>
+          <input type='button' onClick={onCancel} value={'취소하기'} />
         </div>
       </div>
     </>
@@ -89,16 +79,16 @@ function makeMessage(slotId: number, isMatched: boolean) {
 }
 interface EnemyTeam {
   enemyTeam: string[];
-  time: string;
+  slotId: number;
 }
 
-function EnemyTeam({ enemyTeam, time }: EnemyTeam) {
-  if (!isBeforeMin(time, 5) || enemyTeam.length === 0) return <></>;
+function EnemyTeam({ enemyTeam, slotId }: EnemyTeam) {
+  if (!slotId || enemyTeam.length === 0) return <></>;
   const enemyUsers = enemyTeam.map((intraId, index) => (
     <span key={intraId} id={styles.enemyUsers}>
       <Link href={`/users/detail?intraId=${intraId}`}>{intraId}</Link>
       {index < enemyTeam.length - 1 ? ', ' : ''}
     </span>
   ));
-  return <div className={styles.enemyTeam}> 상대팀 : {enemyUsers}</div>;
+  return <div className={styles.enemyTeam}> 상대 : {enemyUsers}</div>;
 }

--- a/components/Layout/NotiItem.tsx
+++ b/components/Layout/NotiItem.tsx
@@ -13,13 +13,13 @@ export default function NotiItem({ data }: NotiItemProps) {
     [key: string]: { [key: string]: string | JSX.Element | undefined };
   } = {
     imminent: {
-      title: '경기 준비',
-      content: MakeImminentContent(data.enemyTeam),
+      title: '삭제 예정',
+      content: '삭제될 타입',
     },
     announce: { title: '공 지', content: makeAnnounceContent(data.message) },
     matched: {
       title: '매칭 성사',
-      content: makeContent(data.id, '번 방 신청한 매칭이 성사되었습니다.'),
+      content: MakeMatchedContent(data.enemyTeam),
     },
     canceledbyman: {
       title: '매칭 취소',
@@ -64,7 +64,7 @@ function makeAnnounceContent(message: string | undefined) {
   );
 }
 
-function MakeImminentContent(enemyTeam: string[] | undefined) {
+function MakeMatchedContent(enemyTeam: string[] | undefined) {
   const setOpenNotiBar = useSetRecoilState(openNotiBarState);
   const makeEnemyUsers = (enemyTeam: string[]) => {
     return enemyTeam.map((intraId: string, i: number) => (


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 매칭 시 notiBar 및 currentMatch 상대방 표기 및 취소 버튼 활성화
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 매칭 잡혔을 시 상단 currentMatch 부분 상대 표시
  - 시간 관계없이 취소 버튼 활성화
  - notiBar 경기 준비 삭제 (5분 전 알림)
  - notiBar 매치 성사에서 상대방 표기
