### PR TITLE
[Fix] challenge 모드 enroll 모드 및 상대 선택 문제 해결 #20

### DIFF
--- a/components/Layout/CurrentMatch.tsx
+++ b/components/Layout/CurrentMatch.tsx
@@ -22,10 +22,21 @@ export default function CurrentMatch() {
     if (reloadMatch) setReloadMatch(false);
   }, [presentPath, reloadMatch]);
 
+  const challengeUnselectCancel = async (slotId: string) => {
+    try {
+      await instance.delete(`/pingpong/match/slots/${slotId}`);
+      setReloadMatch(true);
+    } catch (e: any) {
+      setError('RJ06');
+    }
+  };
+
   const getCurrentMatchHandler = async () => {
     try {
       const res = await instance.get(`/pingpong/match/current`);
       setCurrentMatch(res?.data);
+      if (res.data.mode === 'CHALLENGE' && !res.data.isMatched)
+        await challengeUnselectCancel(res.data.slotId);
     } catch (e) {
       setError('JB01');
     }

--- a/components/Layout/CurrentMatch.tsx
+++ b/components/Layout/CurrentMatch.tsx
@@ -22,21 +22,19 @@ export default function CurrentMatch() {
     if (reloadMatch) setReloadMatch(false);
   }, [presentPath, reloadMatch]);
 
-  const challengeUnselectCancel = async (slotId: string) => {
-    try {
-      await instance.delete(`/pingpong/match/slots/${slotId}`);
-      setReloadMatch(true);
-    } catch (e: any) {
-      setError('RJ06');
-    }
-  };
-
   const getCurrentMatchHandler = async () => {
     try {
       const res = await instance.get(`/pingpong/match/current`);
       setCurrentMatch(res?.data);
-      if (res.data.mode === 'CHALLENGE' && !res.data.isMatched)
-        await challengeUnselectCancel(res.data.slotId);
+      if (res.data.mode === 'CHALLENGE' && !res.data.isMatched) {
+        setModal({
+          modalName: 'MATCH-CHALLENGE',
+          challenge: {
+            slotId: res.data.slotId,
+            type: 'single',
+          },
+        });
+      }
     } catch (e) {
       setError('JB01');
     }

--- a/components/match/MatchSlot.tsx
+++ b/components/match/MatchSlot.tsx
@@ -33,7 +33,7 @@ function MatchSlot({ type, slot, checkBoxMode }: MatchSlotProps) {
 
   const challengeSlotEnroll = async () => {
     try {
-      const body = { slotId: slotId, mode: mode, opponent: null };
+      const body = { slotId: slotId, mode: 'challenge', opponent: null };
       await instance.post(`/pingpong/match/tables/${1}/${type}`, body);
     } catch (e: any) {
       setError('RJ02');
@@ -57,7 +57,6 @@ function MatchSlot({ type, slot, checkBoxMode }: MatchSlotProps) {
         challenge: {
           slotId,
           type,
-          mode: checkBoxMode,
         },
       });
     } else {

--- a/components/modal/match/MatchChallengeModal.tsx
+++ b/components/modal/match/MatchChallengeModal.tsx
@@ -24,8 +24,6 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
   const enrollResponse: { [key: string]: string } = {
     SUCCESS: '경기가 성공적으로 등록되었습니다.',
     SC001: '경기 등록에 실패하였습니다.',
-    SC002: '이미 등록이 완료된 경기입니다.',
-    SC003: '경기 취소 후 1분 동안 경기를 예약할 수 없습니다.',
   };
   const [selectedOpponent, setSelectedOpponent] = useState<Opponent | null>(
     null
@@ -94,12 +92,11 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
       await instance.post(`/pingpong/match/tables/${1}/${type}`, body);
       alert(enrollResponse.SUCCESS);
     } catch (e: any) {
-      if (e.response.data.code in enrollResponse)
+      console.log('enroll e : ', e);
+      if (e.response?.data?.code in enrollResponse)
         alert(enrollResponse[e.response.data.code]);
       else {
-        setModal({ modalName: null });
-        setError('RJ04');
-        return;
+        alert(`잘못된 요청입니다. 페이지를 새로고침 해 주세요!`);
       }
     }
     setModal({ modalName: null });
@@ -110,7 +107,7 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
     try {
       await instance.delete(`/pingpong/match/slots/${slotId}`);
     } catch (e: any) {
-      setError('RJ05');
+      setError('RJ04');
       return;
     }
     setModal({ modalName: null });

--- a/components/modal/match/MatchChallengeModal.tsx
+++ b/components/modal/match/MatchChallengeModal.tsx
@@ -97,7 +97,7 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
       if (e.response?.data?.code in enrollResponse)
         alert(enrollResponse[e.response.data.code]);
       else {
-        alert(`잘못된 요청입니다. 페이지를 새로고침 해 주세요!`);
+        alert(`잘못된 요청입니다!`);
       }
     }
     setModal({ modalName: null });

--- a/components/modal/match/MatchChallengeModal.tsx
+++ b/components/modal/match/MatchChallengeModal.tsx
@@ -36,13 +36,10 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
       detail: '상세 정보1',
     },
     {
-      intraId: 'donghyuk',
-      nick: '42gg의 성시경',
+      intraId: 'intraID22',
+      nick: 'nickname2',
       imageUrl: fallBack,
-      detail:
-        '😵‍💫 막걸리를 좋아함\n' +
-        '🧨 스매싱을 날릴때 주변을 폭파함\n' +
-        '그러나 오늘은 컨디션이 좋지 않음',
+      detail: '상세 정보2',
     },
     {
       intraId: 'intraID3',
@@ -72,6 +69,7 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
   }, [clickReloadChallenge]);
 
   const reloadClickHandler = async () => {
+    setSelectedOpponent(null);
     if (clickReloadChallenge) {
       setSpinReloadButton(true);
       getOpponents();
@@ -83,6 +81,10 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
   };
 
   const onEnroll = async () => {
+    if (selectedOpponent === null) {
+      alert('상대를 선택해 주세요!');
+      return;
+    }
     try {
       const body = {
         slotId,
@@ -92,7 +94,6 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
       await instance.post(`/pingpong/match/tables/${1}/${type}`, body);
       alert(enrollResponse.SUCCESS);
     } catch (e: any) {
-      console.log('enroll e : ', e);
       if (e.response?.data?.code in enrollResponse)
         alert(enrollResponse[e.response.data.code]);
       else {

--- a/components/modal/match/MatchChallengeModal.tsx
+++ b/components/modal/match/MatchChallengeModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
-import { Enroll } from 'types/modalTypes';
+import { Challenge } from 'types/modalTypes';
 import { reloadMatchState } from 'utils/recoil/match';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
@@ -17,7 +17,7 @@ interface Opponent {
   detail: string;
 }
 
-export default function MatchChallengeModal({ slotId, type, mode }: Enroll) {
+export default function MatchChallengeModal({ slotId, type }: Challenge) {
   const setError = useSetRecoilState(errorState);
   const setModal = useSetRecoilState(modalState);
   const setReloadMatch = useSetRecoilState(reloadMatchState);
@@ -88,7 +88,7 @@ export default function MatchChallengeModal({ slotId, type, mode }: Enroll) {
     try {
       const body = {
         slotId,
-        mode,
+        mode: 'challenge',
         opponent: selectedOpponent?.intraId,
       };
       await instance.post(`/pingpong/match/tables/${1}/${type}`, body);

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -31,7 +31,6 @@ export interface Enroll {
 export interface Challenge {
   slotId: number;
   type: string;
-  mode?: MatchMode;
 }
 
 export interface Exp {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 챌린지모드 등록할때 모드 잘못 보내는 문제 해결
  - 챌린지모드 상대 선택 안하고 다른 창 접속했을 때 문제 해결
  - 챌린지 상대 선택 모달 새로고침 시 선택된 상대 초기화 및 선택 안한 상태에서 신청 못하도록 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 챌린지 요청 보낼떼 mode props로 받지 않고 challenge로 입력되도록 변경
  - 챌린지 상대 선택 모달에서 상대를 선택하지 않고 다른 페이지로 이동했을 때 currentMatch에서 방 정보 확인해 취소 요청 전송 추가
  - 챌린지 상대 선택 모달에서 상대를 선택하지 않고 다른 페이지로 이동했을 때 취소 요청 보내는 방법에서 항상 상대 선택 모달을 보내는 방식으로 변경 및 에러 메세지 alert 처리 변경
  - 챌린지 상대 선택 모달 새로고침 시 선택된 상대 초기화 및 선택 안한 상태에서 상대 선택해달라는 alert 뜨게 수정
 
