### PR TITLE
[Fix] 경기 취소 시 1분간 등록 불가 메세지 삭제#29

### DIFF
--- a/components/modal/match/CancelModal.tsx
+++ b/components/modal/match/CancelModal.tsx
@@ -20,7 +20,6 @@ export default function CancelModal({ slotId }: Cancel) {
   const content = {
     emoji: '🤔',
     main: '해당 경기를\n취소하시겠습니까?',
-    sub: '⚠︎ 매칭이 완료된 경기를 취소하면\n1분 간 새로운 예약이 불가합니다!',
   };
   const cancelResponse: { [key: string]: string } = {
     SUCCESS: '경기가 성공적으로 취소되었습니다.',
@@ -70,7 +69,7 @@ export default function CancelModal({ slotId }: Cancel) {
       <div className={styles.phrase}>
         <div className={styles.emoji}>{content.emoji}</div>
         {content.main}
-        {<div className={styles.subContent}>{content.sub}</div>}
+        {<div className={styles.subContent}></div>}
       </div>
       <div className={styles.buttons}>
         {

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -41,7 +41,6 @@ const modalContentsRank: { title: string; description: string[] }[] = [
     description: [
       '등록한 경기가 끝나야만 다음 경기 등록 가능',
       '매칭이 완료되면 상대방이 공개되며\n부스로 방문하여 경기 진행',
-      '매칭이 완료된 상태에서 취소 시,\n1분간 경기 등록 불가',
       '상대방이 경기를 취소하면 매칭 대기 상태로 전환',
     ],
   },


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 경기 취소 시 패널티 기존 1분 등록 불가 삭제
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -  매칭 취소 시 1분 안내 메세지 삭제
  -  메뉴얼에서 매칭 취소 패널티 내용 삭제
 
