### PR TITLE
[Fix] 여러 창에서 challenge 상대 선택 모달을 볼 때 문제 #33

### DIFF
--- a/components/modal/match/CancelModal.tsx
+++ b/components/modal/match/CancelModal.tsx
@@ -25,6 +25,7 @@ export default function CancelModal({ slotId }: Cancel) {
     SUCCESS: '경기가 성공적으로 취소되었습니다.',
     SD001: '이미 지난 경기입니다.',
     SD002: '이미 매칭이 완료된 경기입니다.',
+    E0001: '잘못된 요청입니다.',
   };
 
   useEffect(() => {

--- a/components/modal/match/MatchChallengeModal.tsx
+++ b/components/modal/match/MatchChallengeModal.tsx
@@ -24,6 +24,10 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
   const enrollResponse: { [key: string]: string } = {
     SUCCESS: '경기가 성공적으로 등록되었습니다.',
     SC001: '경기 등록에 실패하였습니다.',
+    E0001: '경기 등록에 실패하였습니다.',
+  };
+  const selectCancelResponse: { [key: string]: string } = {
+    E0001: '잘못된 요청입니다.',
   };
   const [selectedOpponent, setSelectedOpponent] = useState<Opponent | null>(
     null
@@ -94,10 +98,12 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
       await instance.post(`/pingpong/match/tables/${1}/${type}`, body);
       alert(enrollResponse.SUCCESS);
     } catch (e: any) {
-      if (e.response?.data?.code in enrollResponse)
+      if (e.response.data.code in enrollResponse) {
         alert(enrollResponse[e.response.data.code]);
-      else {
-        alert(`잘못된 요청입니다!`);
+      } else {
+        setModal({ modalName: null });
+        setError('RJ04');
+        return;
       }
     }
     setModal({ modalName: null });
@@ -108,7 +114,13 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
     try {
       await instance.delete(`/pingpong/match/slots/${slotId}`);
     } catch (e: any) {
-      alert(`잘못된 요청입니다!`);
+      if (e.response.data.code in selectCancelResponse) {
+        alert(selectCancelResponse[e.response.data.code]);
+      } else {
+        setModal({ modalName: null });
+        setError('RJ05');
+        return;
+      }
     }
     setModal({ modalName: null });
     setReloadMatch(true);

--- a/components/modal/match/MatchChallengeModal.tsx
+++ b/components/modal/match/MatchChallengeModal.tsx
@@ -108,8 +108,7 @@ export default function MatchChallengeModal({ slotId, type }: Challenge) {
     try {
       await instance.delete(`/pingpong/match/slots/${slotId}`);
     } catch (e: any) {
-      setError('RJ03');
-      return;
+      alert(`잘못된 요청입니다!`);
     }
     setModal({ modalName: null });
     setReloadMatch(true);

--- a/components/modal/match/MatchEnrollModal.tsx
+++ b/components/modal/match/MatchEnrollModal.tsx
@@ -2,17 +2,20 @@ import { useSetRecoilState } from 'recoil';
 import { Enroll } from 'types/modalTypes';
 import { reloadMatchState } from 'utils/recoil/match';
 import { modalState } from 'utils/recoil/modal';
+import { errorState } from 'utils/recoil/error';
 import instance from 'utils/axios';
 import styles from 'styles/modal/MatchEnrollModal.module.scss';
 
 export default function MatchEnrollModal({ slotId, type, mode }: Enroll) {
   const setModal = useSetRecoilState(modalState);
   const setReloadMatch = useSetRecoilState(reloadMatchState);
+  const setError = useSetRecoilState(errorState);
   const enrollResponse: { [key: string]: string } = {
     SUCCESS: '경기가 성공적으로 등록되었습니다.',
     SC001: '경기 등록에 실패하였습니다.',
     SC002: '이미 등록이 완료된 경기입니다.',
     SC003: '경기 취소 후 1분 동안 경기를 예약할 수 없습니다.',
+    E0001: '잘못된 요청입니다.',
   };
 
   const onEnroll = async () => {
@@ -21,10 +24,12 @@ export default function MatchEnrollModal({ slotId, type, mode }: Enroll) {
       await instance.post(`/pingpong/match/tables/${1}/${type}`, body);
       alert(enrollResponse.SUCCESS);
     } catch (e: any) {
-      if (e.response.data.code in enrollResponse)
+      if (e.response.data.code in enrollResponse) {
         alert(enrollResponse[e.response.data.code]);
-      else {
-        alert('경기 등록에 실패하였습니다.');
+      } else {
+        setModal({ modalName: null });
+        setError('JH05');
+        return;
       }
     }
     setModal({ modalName: null });


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 상대를 선택해서 슬롯에 신청하지 않고 고르는 모달인 상태로 새 창을 열거나 했을 경우 모달의 취소 버튼을 한번 초과로 누를 경우 빈 슬롯이나 남의 슬롯에 취소 요청을 보낼 때 setError를 alert로 변경
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -  슬롯 취소 요청을 두번 이상 보내더라도 alert으로 잘못된 요청 처리하도록 변경. 가능한 잘못된 요청은 백에서 막힘
 
