### PR TITLE
[Fix] 게임결과 리스트에서 10분이 안지난 경우  시간표시 #35

### DIFF
--- a/utils/handleTime.ts
+++ b/utils/handleTime.ts
@@ -90,7 +90,7 @@ export const getElapsedTimeSeconds = (gameTime: string) => {
  * @return 현재 시간으로부터 얼마 전
  * */
 export const getTimeAgo = (gameTime: string) => {
-  const elapsedTimeSeconds = getElapsedTimeSeconds(gameTime) - 60 * 10;
+  const elapsedTimeSeconds = getElapsedTimeSeconds(gameTime) - 60;
   const timeUnits = [
     { unit: '년', second: 60 * 60 * 24 * 365 },
     { unit: '개월', second: 60 * 60 * 24 * 30 },


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  -  경기 결과 입력 후 10분이 지나기 전까지 방금전으로 뜨는 문제 해결
 
