### PR TITLE
[Fix] currentMatch recoil state 초기화 안되어서 생기는 문제 #44

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -3,7 +3,11 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { userState, liveState } from 'utils/recoil/layout';
-import { reloadMatchState, openCurrentMatchState } from 'utils/recoil/match';
+import {
+  reloadMatchState,
+  openCurrentMatchState,
+  currentMatchState,
+} from 'utils/recoil/match';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
 import { seasonListState } from 'utils/recoil/seasons';
@@ -26,6 +30,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
   );
   const [reloadMatch, setReloadMatch] = useRecoilState(reloadMatchState);
   const setSeasonList = useSetRecoilState(seasonListState);
+  const setCurrentMatch = useSetRecoilState(currentMatchState);
   const setError = useSetRecoilState(errorState);
   const setModal = useSetRecoilState(modalState);
   const presentPath = useRouter().asPath;
@@ -59,6 +64,14 @@ export default function AppLayout({ children }: AppLayoutProps) {
     if (live?.event === 'match') setOpenCurrentMatch(true);
     else {
       if (live?.event === 'game') setModal({ modalName: 'FIXED-AFTER_GAME' });
+      setCurrentMatch({
+        slotId: 0,
+        time: '',
+        isMatched: false,
+        myTeam: [],
+        enemyTeam: [],
+        mode: '',
+      });
       setOpenCurrentMatch(false);
     }
   }, [live]);


### PR DESCRIPTION

<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - currentMatch recoil state 초기화 안되어서 42gg와 함께하기 경기 종료 후에도 체크박스가 선택되어 들어가져서 스크롤 되는 문제 해결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - currentMatch 없어질 때(=openCurrentMatch가 false 될 때), 리코일 값을 초기화하도록 변경
 
