### PR TITLE
[Fix] 42gg와 함께치기 매칭 취소하면 체크박스 해제되어 다시 랭크로 보이는 문제 #72

### DIFF
--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -16,7 +16,8 @@ export default function Match() {
   };
 
   useEffect(() => {
-    setCheckBoxMode(mode === 'CHALLENGE' ? 'challenge' : 'rank');
+    if (mode !== '')
+      setCheckBoxMode(mode === 'CHALLENGE' ? 'challenge' : 'rank');
   }, [mode]);
 
   return (


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 42gg와 함께치기 매칭 취소하면 체크박스 해제되어 다시 랭크로 보이는 문제
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 42gg와 함께치기 매칭 취소해도 체크박스 해제 안되도록 변경